### PR TITLE
Handle null

### DIFF
--- a/src/Turnstile.php
+++ b/src/Turnstile.php
@@ -77,11 +77,16 @@ class Turnstile implements TurnstileContract
     /**
      * Checks the given value against cloudflare's captcha service.
      *
-     * @param  string  $value
+     * @param  null|string  $value
      * @return bool
      */
-    public function check(string $value): bool
+    public function check(?string $value): bool
     {
+        if ($value === null)
+        {
+            return false;
+        }
+        
         $response = $this->request($value);
 
         $this->onResponse($response);


### PR DESCRIPTION
In some cases the value passed in here is `null`, but that's not supported.

Typically this happens when the user submits (i.e. register/login) before Cloudflare is done processing.

```
"LambdaStudio\Turnstile\Turnstile::check(): Argument #1 ($value) must be of type string, null given, called in /var/task/vendor/lambda-studio/turnstile/src/Http/Middleware/ValidTurnstile.php on line 57"
```